### PR TITLE
Enable LZW-compressed strings of 1s and 0s in the query string

### DIFF
--- a/assets/behaviors.js
+++ b/assets/behaviors.js
@@ -1,4 +1,5 @@
 import { Game } from './game.js'
+import { uncompress } from './lzw.js'
 
 // there's gotta be a better way, but we're using modules, so... ¯\_(ツ)_/¯
 let game = null;
@@ -15,6 +16,25 @@ function parseQuery() {
         }
     }
     return values
+}
+
+/**
+ * A string representing a grid should be all 1s and 0s
+ * If it is not, it might have been compressed
+ * @param grid String String of either 1s & 0s or characters representing an LZW-compressed string of 1s & 0s
+ */
+function uncompressGrid(grid) {
+    const rgx = /^[01]+$/
+    // short circuit for an empty string
+    if (!grid) {
+        return grid
+    }
+    // if grid is all 1s & 0s, return it without modification
+    if (rgx.test(grid)) {
+        return grid
+    }
+    // at this point, the string has characters that are not just 1s & 0s, so try uncompressing
+    return uncompress(grid)
 }
 
 function newGame() {
@@ -46,7 +66,7 @@ function readGameOptions() {
         values[name] = getValueFromSelect(select)
     })
     const queryValues = parseQuery()
-    values.grid = queryValues.grid
+    values.grid = uncompressGrid(queryValues.grid)
     return values
 }
 

--- a/assets/game.js
+++ b/assets/game.js
@@ -70,6 +70,9 @@ class Game {
         }
         // reduce the current grid to a string of 1s and 0s
         const reduced = this.reduce(this.board.grid.flat())
+
+console.log(reduced)
+
         // if the current grid is the same as either history, the game is done
         return reduced === this.history[0] || reduced === this.history[1]
     }

--- a/assets/game.js
+++ b/assets/game.js
@@ -70,9 +70,6 @@ class Game {
         }
         // reduce the current grid to a string of 1s and 0s
         const reduced = this.reduce(this.board.grid.flat())
-
-console.log(reduced)
-
         // if the current grid is the same as either history, the game is done
         return reduced === this.history[0] || reduced === this.history[1]
     }

--- a/assets/lzw.js
+++ b/assets/lzw.js
@@ -57,7 +57,7 @@ const compress = (str, asArray) => {
         ASCII += String.fromCharCode(dict[w])
     }
     return asArray ? result : ASCII
-};
+}
 
 const uncompress = str => {
     // Build the dictionary.


### PR DESCRIPTION
This change makes it possible to use [LZW](https://en.wikipedia.org/wiki/Lempel%E2%80%93Ziv%E2%80%93Welch)-compressed query strings to configure the initial board state. E.g., this is [an example of a 32x32 board configured this way](http://segdelife.netlify.app/?grid=0%C4%8001%C4%83%C4%84%C4%84%C4%81%C4%801%C4%87%C4%8A%C4%87%C4%83%C4%8A%C4%85%C4%89%C4%89%C4%8E%C4%8B%C4%93%C4%86%C4%93%C4%8C%C4%8D%C4%81%C4%95%C4%8B%C4%90%C4%82%C4%9D%C4%88%C4%99%C4%91%C4%82%C4%85%C4%94%C4%8C%C4%9E%C4%A0%C4%9F%C4%A4%C4%90%C4%A1%C4%96%C4%A5%C4%AB%C4%97%C4%91%C4%98%C4%98%C4%9F%C4%AE%C4%9E%C4%A1%C4%AE%C4%A3%C4%B4%C4%A6%C4%A8%C4%97%C4%BC%C4%B4%C4%B0%C4%96%C4%9A%C4%AB%C4%B0%C4%B2%C4%A2%C5%82%C5%85%C4%86%C5%84%C4%A7%C4%BA%C4%B6%C4%B9%C4%A2%C4%99%C4%A8%C5%8C%C4%B7%C5%8E%C5%8A%C4%A0%C4%9C%C4%92%C4%AF%C4%AD%C4%9B%C5%8F%C5%89%C5%97%C4%9D%C4%B9%C5%88%C4%AC%C4%B7%C5%96%C5%98%C5%A3%C4%AC%C5%8E%C5%92%C5%83%C4%88%C5%8D%C4%BC%C4%92%C4%8D%C4%B1%C5%AB%C4%B5%C4%B6%C5%AD%C5%B0%C4%B3%C5%8F%C5%80%C5%A6%C5%AD%C5%B6%C5%90%C5%84%C5%9C%C5%A6%C5%A8%C5%BD%C5%B8%C5%80%C4%8F%C5%86%C6%81%C4%BB%C6%86%C4%B2%C6%80%C5%9A%C5%BA%C6%8A%C4%BA%C5%A1%C6%8B%C5%9E%C4%BF%C5%AA%C5%8D%C6%84%C6%90%C4%A5%C5%A7%C5%9A%C6%94%C5%A5%C5%94%C4%9B%C5%AE%C5%AF%C6%85%C6%82%C5%92%C5%B6%C5%B4%C6%87%C4%94%C4%BF%C4%AA%C5%99%C6%83%C6%80%C4%B8%C5%BC%C6%95%C6%9B%C4%83).

The purpose of this change is to make it possible to configure even 128x128 grids via the query string. Most browsers can only handle a few thousand characters for an URL. 128 x 128 > 16000, but the same string LZW-compressed is on the order of 1000 characters.